### PR TITLE
feat: common BaseEntity 및 JPA Auditing설정 추가

### DIFF
--- a/common-server/build.gradle
+++ b/common-server/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/common-server/src/main/java/org/sixpang/commonserver/audit/AuditorAwareImpl.java
+++ b/common-server/src/main/java/org/sixpang/commonserver/audit/AuditorAwareImpl.java
@@ -1,0 +1,18 @@
+package org.sixpang.commonserver.audit;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<UUID> {
+
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+        return Optional.of(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        //나중에 JWT 만들어지면 SecurityContextHolder.getContext().getAuthentication()으로 UUID값 받아와야됨
+    }
+}

--- a/common-server/src/main/java/org/sixpang/commonserver/config/JpaConfig.java
+++ b/common-server/src/main/java/org/sixpang/commonserver/config/JpaConfig.java
@@ -1,0 +1,19 @@
+package org.sixpang.commonserver.config;
+
+import org.sixpang.commonserver.audit.AuditorAwareImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.UUID;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+    @Bean
+    public AuditorAware<UUID> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+}

--- a/common-server/src/main/java/org/sixpang/commonserver/entity/BaseEntity.java
+++ b/common-server/src/main/java/org/sixpang/commonserver/entity/BaseEntity.java
@@ -1,0 +1,44 @@
+package org.sixpang.commonserver.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", nullable = false, updatable = false)
+    private UUID createdBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private UUID updatedBy;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private UUID deletedBy;
+
+
+}


### PR DESCRIPTION
## 🔗 Issue Number
Closes #2

## 📝 작업 내역

- BaseEntity 공통 필드 생성
- JPA Auditing 설정
- AuditorAware 구현으로 생성자/수정자 자동 주입 구조 추가
-
## 💡 PR 특이사항

-- createdBy, updatedBy는 현재 테스트용 UUID 값을 임의로 집어 넣은 상태
- 추후 JWT 기반 인증 구현 후 SecurityContext에서 사용자 UUID를 가져오도록 변경 예정
- 특이사항
