### PR TITLE
Feature/#84 user 역할 기반 접근 통제 적용 

### DIFF
--- a/common-server/src/main/java/org/sixpang/commonserver/enums/UserRole.java
+++ b/common-server/src/main/java/org/sixpang/commonserver/enums/UserRole.java
@@ -1,4 +1,4 @@
-package org.sixpang.userservice.domain.model.enums;
+package org.sixpang.commonserver.enums;
 
 public enum UserRole {
     MASTER,           // 마스터 관리자

--- a/gateway-server/src/main/java/org/sixpang/gatewayserver/common/UserRole.java
+++ b/gateway-server/src/main/java/org/sixpang/gatewayserver/common/UserRole.java
@@ -1,9 +1,0 @@
-package org.sixpang.gatewayserver.common;
-
-/** 사용자 권한 enum */
-public enum UserRole {
-    MASTER,           // 마스터 관리자
-    HUB_MANAGER,      // 허브 관리자
-    COMPANY_MANAGER,  // 업체 관리자
-    DRIVER_MANAGER    // 배송 담당자
-}

--- a/gateway-server/src/main/resources/application.yaml
+++ b/gateway-server/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ spring:
         - id: prediction-service
           uri: lb://prediction-service
           predicates:
-            - Path=/api/prediction/**
+            - Path=/api/predictions/**
 
 eureka:
   client:

--- a/gateway-server/src/main/resources/application.yaml
+++ b/gateway-server/src/main/resources/application.yaml
@@ -46,7 +46,7 @@ spring:
         - id: hub-service
           uri: lb://hub-service
           predicates:
-            - Path=/api/hub/**
+            - Path=/api/hubs/**
 
         - id: notification-service
           uri: lb://notification-service

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     runtimeOnly 'org.postgresql:postgresql'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/user-service/src/main/java/org/sixpang/userservice/application/dto/UserServiceDto.java
+++ b/user-service/src/main/java/org/sixpang/userservice/application/dto/UserServiceDto.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sixpang.userservice.domain.model.entity.User;
-import org.sixpang.userservice.domain.model.enums.UserRole;
+import org.sixpang.commonserver.enums.UserRole;
 
 import java.util.UUID;
 

--- a/user-service/src/main/java/org/sixpang/userservice/application/dto/query/AuthUser.java
+++ b/user-service/src/main/java/org/sixpang/userservice/application/dto/query/AuthUser.java
@@ -3,7 +3,7 @@ package org.sixpang.userservice.application.dto.query;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.sixpang.userservice.domain.model.entity.User;
-import org.sixpang.userservice.domain.model.enums.UserRole;
+import org.sixpang.commonserver.enums.UserRole;
 import org.sixpang.userservice.domain.model.enums.UserStatus;
 
 import java.util.UUID;

--- a/user-service/src/main/java/org/sixpang/userservice/application/dto/query/UserDetail.java
+++ b/user-service/src/main/java/org/sixpang/userservice/application/dto/query/UserDetail.java
@@ -3,7 +3,7 @@ package org.sixpang.userservice.application.dto.query;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.sixpang.userservice.domain.model.entity.User;
-import org.sixpang.userservice.domain.model.enums.UserRole;
+import org.sixpang.commonserver.enums.UserRole;
 import org.sixpang.userservice.domain.model.enums.UserStatus;
 
 import java.time.LocalDateTime;

--- a/user-service/src/main/java/org/sixpang/userservice/application/dto/query/UserInfo.java
+++ b/user-service/src/main/java/org/sixpang/userservice/application/dto/query/UserInfo.java
@@ -3,7 +3,7 @@ package org.sixpang.userservice.application.dto.query;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.sixpang.userservice.domain.model.entity.User;
-import org.sixpang.userservice.domain.model.enums.UserRole;
+import org.sixpang.commonserver.enums.UserRole;
 import org.sixpang.userservice.domain.model.enums.UserStatus;
 
 import java.util.UUID;

--- a/user-service/src/main/java/org/sixpang/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/org/sixpang/userservice/application/service/UserService.java
@@ -3,6 +3,7 @@ package org.sixpang.userservice.application.service;
 import lombok.RequiredArgsConstructor;
 import org.sixpang.userservice.application.dto.UserServiceDto;
 import org.sixpang.userservice.domain.model.entity.User;
+import org.sixpang.commonserver.enums.UserRole;
 import org.sixpang.userservice.domain.model.enums.UserStatus;
 import org.sixpang.userservice.domain.repository.UserRepository;
 import org.sixpang.userservice.exception.UserErrorCode;
@@ -43,7 +44,9 @@ public class UserService {
     }
 
     /**회원 정보 수정**/
-    public void updateUser(UUID userId, UserServiceDto.Update dto) {
+    public void updateUser(UUID userId, UUID currentUserId, UserRole role, UserServiceDto.Update dto) {
+
+        validateAccess(userId, currentUserId, role);
 
         User user = findUser(userId);
 
@@ -61,7 +64,9 @@ public class UserService {
     }
 
     /**비밀번호 변경 **/
-    public void changePassword(UUID userId, UserServiceDto.ChangePassword dto) {
+    public void changePassword(UUID userId, UUID currentUserId, UserRole role, UserServiceDto.ChangePassword dto) {
+
+        validateAccess(userId, currentUserId, role);
 
         User user = findUser(userId);
 
@@ -93,7 +98,9 @@ public class UserService {
     }
 
     /**회원삭제**/
-    public void deleteUser(UUID userId, UUID currentUserId) {
+    public void deleteUser(UUID userId, UUID currentUserId, UserRole role) {
+
+        validateAccess(userId, currentUserId, role);
 
         User user = findUser(userId);
 
@@ -126,6 +133,13 @@ public class UserService {
         // 전화 번호 중복 체크 (코드 리뷰:예외 처리 조건이 명확 하게 드러나도록 분기문 유지)
         if (isAlreadyExistsPhone(dto.getPhone())) {
             throw new UserException(UserErrorCode.EXISTS_PHONE);
+        }
+    }
+
+    //권한 체크 메서드
+    private void validateAccess(UUID targetUserId, UUID currentUserId, UserRole role) {
+        if (!targetUserId.equals(currentUserId) && role != UserRole.MASTER) {
+            throw new UserException(UserErrorCode.FORBIDDEN);
         }
     }
 }

--- a/user-service/src/main/java/org/sixpang/userservice/domain/model/entity/User.java
+++ b/user-service/src/main/java/org/sixpang/userservice/domain/model/entity/User.java
@@ -5,7 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sixpang.commonserver.entity.BaseEntity;
-import org.sixpang.userservice.domain.model.enums.UserRole;
+import org.sixpang.commonserver.enums.UserRole;
 import org.sixpang.userservice.domain.model.enums.UserStatus;
 import org.sixpang.userservice.exception.UserErrorCode;
 import org.sixpang.userservice.exception.UserException;

--- a/user-service/src/main/java/org/sixpang/userservice/exception/UserErrorCode.java
+++ b/user-service/src/main/java/org/sixpang/userservice/exception/UserErrorCode.java
@@ -15,7 +15,9 @@ public enum UserErrorCode implements ErrorCode {
     ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "이미 승인된 상태입니다."),
     ALREADY_REJECTED(HttpStatus.BAD_REQUEST, "이미 거절된 상태입니다."),
     CANNOT_APPROVE(HttpStatus.BAD_REQUEST, "승인할 수 없는 상태입니다."),
-    CANNOT_REJECT(HttpStatus.BAD_REQUEST, "거절할 수 없는 상태입니다.");
+    CANNOT_REJECT(HttpStatus.BAD_REQUEST, "거절할 수 없는 상태입니다."),
+
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/user-service/src/main/java/org/sixpang/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/org/sixpang/userservice/presentation/controller/UserController.java
@@ -9,7 +9,7 @@ import org.sixpang.userservice.application.dto.query.UserInfo;
 import org.sixpang.userservice.application.dto.query.AuthUser;
 import org.sixpang.userservice.application.service.UserQueryService;
 import org.sixpang.userservice.application.service.UserService;
-import org.sixpang.userservice.domain.model.enums.UserRole;
+import org.sixpang.commonserver.enums.UserRole;
 import org.sixpang.userservice.domain.model.enums.UserStatus;
 import org.sixpang.userservice.presentation.dto.PageResponseDto;
 import org.sixpang.userservice.presentation.dto.UserRequestDto;
@@ -18,6 +18,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.List;
 import java.util.UUID;
@@ -62,6 +66,7 @@ public class UserController {
     }
 
     /**단건 조회**/
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<UserResponseDto.UserDetailResponse>> getUser(
             @PathVariable UUID id
@@ -86,6 +91,7 @@ public class UserController {
     }
 
     /**목록 조회**/
+    @PreAuthorize("hasRole('MASTER')")
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponseDto<List<UserResponseDto.UserResponse>>>> getUsers(Pageable pageable) {
 
@@ -117,13 +123,20 @@ public class UserController {
     }
 
     /**회원 정보 수정***/
+    @PreAuthorize("isAuthenticated()")
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<UserResponseDto.UserUpdateResponse>> updateUser(
             @PathVariable UUID id,
             @Valid @RequestBody UserRequestDto.UpdateUserRequest request
     ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UUID currentUserId = UUID.fromString(authentication.getName());
+        UserRole role = UserRole.valueOf(authentication.getAuthorities().iterator().next().getAuthority().replace("ROLE_", ""));
+
         userService.updateUser(
                 id,
+                currentUserId,
+                role,
                 UserServiceDto.Update.builder()
                         .name(request.getName())
                         .phone(request.getPhone())
@@ -148,13 +161,20 @@ public class UserController {
     }
 
     /**비밀번호 변경**/
+    @PreAuthorize("isAuthenticated()")
     @PatchMapping("/{id}/password")
     public ResponseEntity<ApiResponse<Void>> changePassword(
             @PathVariable UUID id,
             @Valid @RequestBody UserRequestDto.ChangePasswordRequest request
     ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UUID currentUserId = UUID.fromString(authentication.getName());
+        UserRole role = UserRole.valueOf(authentication.getAuthorities().iterator().next().getAuthority().replace("ROLE_", ""));
+
         userService.changePassword(
                 id,
+                currentUserId,
+                role,
                 UserServiceDto.ChangePassword.builder()
                         .currentPassword(request.getCurrentPassword())
                         .newPassword(request.getNewPassword())
@@ -165,6 +185,7 @@ public class UserController {
     }
 
     /**회원 상태 변경**/
+    @PreAuthorize("hasRole('MASTER')")
     @PatchMapping("/{id}/status")
     public ResponseEntity<ApiResponse<UserResponseDto.UserSimpleResponse>> changeStatus(
             @PathVariable UUID id,
@@ -188,12 +209,15 @@ public class UserController {
     }
 
     /**회원 삭제**/
+    @PreAuthorize("hasRole('MASTER')")
     @DeleteMapping("/{userId}")
     public ResponseEntity<ApiResponse<Void>> deleteUser(@PathVariable UUID userId) {
 
-        UUID currentUserId = UUID.randomUUID();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UUID currentUserId = UUID.fromString(authentication.getName());
+        UserRole role = UserRole.valueOf(authentication.getAuthorities().iterator().next().getAuthority().replace("ROLE_", ""));
 
-        userService.deleteUser(userId, currentUserId);
+        userService.deleteUser(userId, currentUserId, role);
 
         return ResponseEntity.ok(
                 ApiResponse.of("회원 삭제가 완료되었습니다.", null)

--- a/user-service/src/main/java/org/sixpang/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/org/sixpang/userservice/presentation/controller/UserController.java
@@ -3,6 +3,7 @@ package org.sixpang.userservice.presentation.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sixpang.commonserver.response.ApiResponse;
+import org.sixpang.commonserver.security.UserPrincipal;
 import org.sixpang.userservice.application.dto.UserServiceDto;
 import org.sixpang.userservice.application.dto.query.UserDetail;
 import org.sixpang.userservice.application.dto.query.UserInfo;
@@ -11,17 +12,18 @@ import org.sixpang.userservice.application.service.UserQueryService;
 import org.sixpang.userservice.application.service.UserService;
 import org.sixpang.commonserver.enums.UserRole;
 import org.sixpang.userservice.domain.model.enums.UserStatus;
+import org.sixpang.userservice.exception.UserErrorCode;
+import org.sixpang.userservice.exception.UserException;
 import org.sixpang.userservice.presentation.dto.PageResponseDto;
 import org.sixpang.userservice.presentation.dto.UserRequestDto;
 import org.sixpang.userservice.presentation.dto.UserResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.List;
 import java.util.UUID;
@@ -69,12 +71,46 @@ public class UserController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<UserResponseDto.UserDetailResponse>> getUser(
-            @PathVariable UUID id
+            @PathVariable UUID id,
+            @AuthenticationPrincipal UserPrincipal user
     ) {
+        UUID currentUserId = user.getUserId();
+        UserRole role = UserRole.valueOf(user.getRole());
+
+        // 조회 권한 (본인 or MASTER)
+        if (!id.equals(currentUserId) && role != UserRole.MASTER) {
+            throw new UserException(UserErrorCode.FORBIDDEN);
+        }
+
         UserDetail dto = userQueryService.getUser(id);
 
         return ResponseEntity.ok(
                 ApiResponse.of("회원 상세 조회 성공",
+                        new UserResponseDto.UserDetailResponse(
+                                dto.getId(),
+                                dto.getEmail(),
+                                dto.getName(),
+                                dto.getPhone(),
+                                dto.getSlackId(),
+                                dto.getRole().name(),
+                                dto.getStatus().name(),
+                                dto.getHubId(),
+                                dto.getCompanyId()
+                        )
+                )
+        );
+    }
+
+    /**내 정보 조회**/
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponseDto.UserDetailResponse>> getMyUser(
+            @AuthenticationPrincipal UserPrincipal user
+    ) {
+        UserDetail dto = userQueryService.getUser(user.getUserId());
+
+        return ResponseEntity.ok(
+                ApiResponse.of("내 정보 조회 성공",
                         new UserResponseDto.UserDetailResponse(
                                 dto.getId(),
                                 dto.getEmail(),
@@ -127,11 +163,11 @@ public class UserController {
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<UserResponseDto.UserUpdateResponse>> updateUser(
             @PathVariable UUID id,
+            @AuthenticationPrincipal UserPrincipal user,
             @Valid @RequestBody UserRequestDto.UpdateUserRequest request
     ) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        UUID currentUserId = UUID.fromString(authentication.getName());
-        UserRole role = UserRole.valueOf(authentication.getAuthorities().iterator().next().getAuthority().replace("ROLE_", ""));
+        UUID currentUserId = user.getUserId();
+        UserRole role = UserRole.valueOf(user.getRole());
 
         userService.updateUser(
                 id,
@@ -160,21 +196,52 @@ public class UserController {
         );
     }
 
-    /**비밀번호 변경**/
+    /**내 정보 수정**/
     @PreAuthorize("isAuthenticated()")
-    @PatchMapping("/{id}/password")
-    public ResponseEntity<ApiResponse<Void>> changePassword(
-            @PathVariable UUID id,
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponseDto.UserUpdateResponse>> updateMyUser(
+            @AuthenticationPrincipal UserPrincipal user,
+            @Valid @RequestBody UserRequestDto.UpdateUserRequest request
+    ) {
+        userService.updateUser(
+                user.getUserId(),
+                user.getUserId(),
+                UserRole.valueOf(user.getRole()),
+                UserServiceDto.Update.builder()
+                        .name(request.getName())
+                        .phone(request.getPhone())
+                        .slackId(request.getSlackId())
+                        .build()
+        );
+
+        UserDetail dto = userQueryService.getUser(user.getUserId());
+
+        return ResponseEntity.ok(
+                ApiResponse.of("내 정보 수정이 완료되었습니다.",
+                        new UserResponseDto.UserUpdateResponse(
+                                dto.getId(),
+                                dto.getName(),
+                                dto.getPhone(),
+                                dto.getRole().name(),
+                                dto.getHubId(),
+                                dto.getCompanyId()
+                        )
+                )
+        );
+    }
+
+
+    /**내 비밀번호 변경**/
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping("/me/password")
+    public ResponseEntity<ApiResponse<Void>> changeMyPassword(
+            @AuthenticationPrincipal UserPrincipal user,
             @Valid @RequestBody UserRequestDto.ChangePasswordRequest request
     ) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        UUID currentUserId = UUID.fromString(authentication.getName());
-        UserRole role = UserRole.valueOf(authentication.getAuthorities().iterator().next().getAuthority().replace("ROLE_", ""));
-
         userService.changePassword(
-                id,
-                currentUserId,
-                role,
+                user.getUserId(),
+                user.getUserId(),
+                UserRole.valueOf(user.getRole()),
                 UserServiceDto.ChangePassword.builder()
                         .currentPassword(request.getCurrentPassword())
                         .newPassword(request.getNewPassword())
@@ -185,7 +252,7 @@ public class UserController {
     }
 
     /**회원 상태 변경**/
-    @PreAuthorize("hasRole('MASTER')")
+    @PreAuthorize("hasAnyRole('MASTER', 'HUB_MANAGER')")
     @PatchMapping("/{id}/status")
     public ResponseEntity<ApiResponse<UserResponseDto.UserSimpleResponse>> changeStatus(
             @PathVariable UUID id,
@@ -211,16 +278,29 @@ public class UserController {
     /**회원 삭제**/
     @PreAuthorize("hasRole('MASTER')")
     @DeleteMapping("/{userId}")
-    public ResponseEntity<ApiResponse<Void>> deleteUser(@PathVariable UUID userId) {
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        UUID currentUserId = UUID.fromString(authentication.getName());
-        UserRole role = UserRole.valueOf(authentication.getAuthorities().iterator().next().getAuthority().replace("ROLE_", ""));
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
+            @PathVariable UUID userId,
+            @AuthenticationPrincipal UserPrincipal user
+    ) {
+        UUID currentUserId = user.getUserId();
+        UserRole role = UserRole.valueOf(user.getRole());
 
         userService.deleteUser(userId, currentUserId, role);
 
         return ResponseEntity.ok(
                 ApiResponse.of("회원 삭제가 완료되었습니다.", null)
+        );
+    }
+
+    /**회원 탈퇴**/
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deleteMyAccount(
+            @AuthenticationPrincipal UserPrincipal user
+    ) {
+        userService.deleteUser(user.getUserId(), user.getUserId(), UserRole.valueOf(user.getRole()));
+
+        return ResponseEntity.ok(
+                ApiResponse.of("회원 탈퇴가 완료되었습니다.", null)
         );
     }
 


### PR DESCRIPTION
## 🔗 Issue Number
- 이슈 번호#84 

## 📝 작업 내역

- user service , user controller 역할기반접근 통제 적용
- gateway yaml파일 predictions 오타수정
- common모듈에 UserRole enums 추가 

## 💡 PR 특이사항

현재 권한 체크를 @PreAuthorize 기반으로 구현완료

다만, 테스트 과정에서 Security 레벨에서 예외가 발생할 경우
GlobalExceptionHandler로 일관된 응답 처리가 되지 않는 문제가 있습니다
(흐름: 요청 → Security 필터 → @PreAuthorize 검사 → AuthorizationDeniedException 발생 → Controller 진입 실패 → GlobalExceptionHandler 미동작)

이에 대해 다음과 같은 대안을 고민 중
1. Spring Security(@PreAuthorize) 유지 + AccessDeniedHandler 추가해서 잡을지
2. Service 레이어에서 권한 체크로 통일 
3. 작동은 잘되나 에러 응답 문제 이므로 보류하기 -> 다른 개발사항에 더 집중
4. AOP 기반 커스텀 어노테이션(@RequiredRoles)으로 권한 처리 
Controller 진입 → AOP 권한 체크 → 예외 발생 → GlobalExceptionHandler 처리)  
   (구현 난이도는 있으나 구조적으로 가장 깔끔한 방식, 각자 공부해야함 )

---

현재는 기존 방식(@PreAuthorize)을 유지한 상태로 PR 올립니다 

4번인 AOP 기반 커스텀 어노테이션은 common 모듈에 구현하여  
각 서비스에서 공통적으로 사용할 수 있도록 확장해야해서 의견부탁드립니다
각 장단점이있어서 맞는방법은없고  
월요일에 튜터님께 AOP방식에대해 구체적으로 물어보고 결정하고싶은데 
팀원분들도 권한체크 구현 할때 같이 알아가시면 좋을거같아서 올려보아요  


AOP 기반 커스텀 어노테이션문서 
https://velog.io/@kyoung0161/SpringPreAuthorize%EC%9D%98-%ED%95%9C%EA%B3%84-%EC%BB%A4%EC%8A%A4%ED%85%80-%EC%96%B4%EB%85%B8%ED%85%8C%EC%9D%B4%EC%85%98-AOP%EB%A1%9C-%ED%95%B4%EA%B2%B0