### PR TITLE
FIX/#88 page응답 dto 생성 후 controller 적용

### DIFF
--- a/common-server/src/main/java/org/sixpang/commonserver/response/PageResponse.java
+++ b/common-server/src/main/java/org/sixpang/commonserver/response/PageResponse.java
@@ -1,0 +1,23 @@
+package org.sixpang.commonserver.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+    public static <T> PageResponse<T> from(Page<T> page){
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+    }
+}

--- a/company-service/company-test.http
+++ b/company-service/company-test.http
@@ -1,4 +1,4 @@
-@host = http://localhost:51729
+@host = http://localhost:53438
 @companyId = 3bfc578e-51bd-4a22-8926-7c368d23498a
 
 ### 업체 생성
@@ -34,3 +34,7 @@ Content-Type: application/json
 ### 업체 삭제
 DELETE {{host}}/api/companies/{{companyId}}
 Content-Type: application/json
+
+### 상품 목록 조회 (Page 그대로 응답)
+GET {{host}}/api/companies?page=0&size=999}
+Accept: application/json

--- a/company-service/src/main/java/org/sixpang/companyservice/presentation/CompanyController.java
+++ b/company-service/src/main/java/org/sixpang/companyservice/presentation/CompanyController.java
@@ -2,6 +2,7 @@ package org.sixpang.companyservice.presentation;
 
 import lombok.RequiredArgsConstructor;
 import org.sixpang.commonserver.response.ApiResponse;
+import org.sixpang.commonserver.response.PageResponse;
 import org.sixpang.companyservice.application.CompanyService;
 import org.sixpang.companyservice.application.dto.CompanyResponse;
 import org.sixpang.companyservice.application.dto.CompanySearchRequest;
@@ -42,14 +43,15 @@ public class CompanyController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<Page<CompanyResponse>>> getCompanies(
+    public ResponseEntity<ApiResponse<PageResponse<CompanyResponse>>> getCompanies(
             @RequestParam(required = false) String name,
             @RequestParam(required = false) CompanyType type,
             @RequestParam(required = false) UUID hubId,
             @RequestParam(required = false) String address,
             Pageable pageable) {
         CompanySearchRequest request = new CompanySearchRequest(name, address,type,hubId);
-        Page<CompanyResponse> response = companyService.getCompanies(request,pageable);
+        Page<CompanyResponse> companies = companyService.getCompanies(request,pageable);
+        PageResponse<CompanyResponse> response = PageResponse.from(companies);
         return ResponseEntity.ok(ApiResponse.of("업체 목록 조회 성공", response));
     }
 


### PR DESCRIPTION
## 🔗 Issue Number
close #88 

## 📝 작업 내역

- common-server에 공통 PageResponse DTO 추가
- page 객체를 그대로 반환하던 구조를 개선하기 위해 변환 로직 구현
- Company 목록 조회 API에 PageResponse 적용

## 💡 PR 특이사항


